### PR TITLE
fix: Fix dashboard pathing

### DIFF
--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -83,3 +83,18 @@ services:
       - "traefik.http.services.hma_glacial_lakes-app.loadbalancer.server.port=8080"
       - "traefik.http.routers.hma_glacial_lakes-app.entrypoints=web"
       - "traefik.http.routers.hma_glacial_lakes-app.rule=PathPrefix(`/hma_glacial_lakes`)"
+
+  dtcg_l2_dashboard-app:
+    image: "ghcr.io/oggm/bokeh:20230101"
+    container_name: "dtcg_l2_dashboard-app"
+    command:
+      - "git+https://github.com/DTC-Glaciers/dtcg-web.git@v0.1.1"
+      - "fastapi run dtcgweb/main.py"
+    environment:
+      - "BOKEH_PREFIX=/dtcg_l2_dashboard"
+      - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.dtcg_l2_dashboard-app.loadbalancer.server.port=8080"
+      - "traefik.http.routers.dtcg_l2_dashboard-app.entrypoints=web"
+      - "traefik.http.routers.dtcg_l2_dashboard-app.rule=PathPrefix(`/dtcg_l2_dashboard`)"

--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -88,9 +88,8 @@ services:
     image: "ghcr.io/oggm/bokeh:20250915"
     container_name: "dtcg_l2_dashboard-app"
     command:
-      - "git+https://github.com/DTC-Glaciers/dtcg-web.git@v0.1.1"
-      - "cd src/dtcgweb"
-      - "main.py"
+      - "git+https://github.com/DTC-Glaciers/dtcg-web.git@v0.1.2"
+      - "src/dtcgweb/main.py"
     environment:
       - "BOKEH_PREFIX=/dtcg_l2_dashboard"
       - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"

--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -85,11 +85,12 @@ services:
       - "traefik.http.routers.hma_glacial_lakes-app.rule=PathPrefix(`/hma_glacial_lakes`)"
 
   dtcg_l2_dashboard-app:
-    image: "ghcr.io/oggm/bokeh:20230101"
+    image: "ghcr.io/oggm/bokeh:20250915"
     container_name: "dtcg_l2_dashboard-app"
     command:
       - "git+https://github.com/DTC-Glaciers/dtcg-web.git@v0.1.1"
-      - "fastapi run dtcgweb/main.py"
+      - "cd src/dtcgweb"
+      - "main.py"
     environment:
       - "BOKEH_PREFIX=/dtcg_l2_dashboard"
       - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"

--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -84,17 +84,19 @@ services:
       - "traefik.http.routers.hma_glacial_lakes-app.entrypoints=web"
       - "traefik.http.routers.hma_glacial_lakes-app.rule=PathPrefix(`/hma_glacial_lakes`)"
 
-  dtcg_l2_dashboard-app:
+  dtcgweb-app:
     image: "ghcr.io/oggm/bokeh:20250915"
-    container_name: "dtcg_l2_dashboard-app"
-    command:
-      - "git+https://github.com/DTC-Glaciers/dtcg-web.git@v0.1.2"
-      - "src/dtcgweb/main.py"
+    container_name: "dtcgweb-app"
+    build:
+      context: https://github.com/DTC-Glaciers/dtcg-web.git#v0.1.3
+      args:
+        - "BOKEH_PREFIX=/dtcgweb"
+        - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
     environment:
-      - "BOKEH_PREFIX=/dtcg_l2_dashboard"
+      - "BOKEH_PREFIX=/dtcgweb"
       - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.services.dtcg_l2_dashboard-app.loadbalancer.server.port=8080"
-      - "traefik.http.routers.dtcg_l2_dashboard-app.entrypoints=web"
-      - "traefik.http.routers.dtcg_l2_dashboard-app.rule=PathPrefix(`/dtcg_l2_dashboard`)"
+      - "traefik.http.services.dtcgweb-app.loadbalancer.server.port=8080"
+      - "traefik.http.routers.dtcgweb-app.entrypoints=web"
+      - "traefik.http.routers.dtcgweb-app.rule=PathPrefix(`/dtcgweb`)"

--- a/bokeh.oggm.org/static/htdocs/index.html
+++ b/bokeh.oggm.org/static/htdocs/index.html
@@ -16,4 +16,5 @@ Otherwise, jump to:<br>
 <li>the <a href="explorer"> World Glaciers Explorer app</a></li>
 <li>the <a href="mb_simulator"> Mass-Balance Simulator app</a></li>
 <li>the <a href="hma_glacial_lakes"> HMA Glacial Lakes app</a></li>
+<li>the <a href="dtcgweb"> DTCG Web Dashboard</a></li>
 </p>

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -2,7 +2,7 @@
 set -xe
 
 rm -rf repo
-git clone https://github.com/OGGM/Bokeh-Docker.git repo
+git clone --branch feat-l2-dashboard https://github.com/OGGM/Bokeh-Docker.git repo
 cd repo/bokeh.oggm.org
 
 docker compose down --remove-orphans

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -2,7 +2,7 @@
 set -xe
 
 rm -rf repo
-git clone --branch feat-l2-dashboard https://github.com/OGGM/Bokeh-Docker.git repo
+git clone --branch feat-l2-dashboard https://github.com/gampnico/Bokeh-Docker.git repo
 cd repo/bokeh.oggm.org
 
 docker compose down --remove-orphans

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -2,7 +2,7 @@
 set -xe
 
 rm -rf repo
-git clone --branch feat-l2-dashboard https://github.com/gampnico/Bokeh-Docker.git repo
+git clone https://github.com/OGGM/Bokeh-Docker.git repo
 cd repo/bokeh.oggm.org
 
 docker compose down --remove-orphans


### PR DESCRIPTION
Refactors docker-compose to use a build context for dtcg-web. This was the only solution I found to ensure nginx points to the right folder.

@TimoRoth I made assumptions about your setup and tested this via Docker-in-Docker, i.e:
```
cd runner/
docker build -t bokeh_runner . --no-cache
docker run -v /var/run/docker.sock:/var/run/docker.sock -d --name bokeh_server -p 8080:8080 bokeh_runner
```

@TimoRoth, @fmaussion  this may introduce extra load on the cluster as dtcg-web has to be built, but I have tied it to the dtcg-web's version number so this should only occur if you accept a pull request to change it. Since the priority is to have something available for users to see, may I find a solution to this at a later date?