### PR TITLE
fix: fix build pathing, pin DTCG-Web version

### DIFF
--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -85,10 +85,9 @@ services:
       - "traefik.http.routers.hma_glacial_lakes-app.rule=PathPrefix(`/hma_glacial_lakes`)"
 
   dtcgweb-app:
-    image: "ghcr.io/oggm/bokeh:20250915"
     container_name: "dtcgweb-app"
     build:
-      context: https://github.com/DTC-Glaciers/dtcg-web.git#v0.1.3
+      context: https://github.com/DTC-Glaciers/dtcg-web.git#v0.1.4
       args:
         - "BOKEH_PREFIX=/dtcgweb"
         - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"

--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -88,9 +88,6 @@ services:
     container_name: "dtcgweb-app"
     build:
       context: https://github.com/DTC-Glaciers/dtcg-web.git#v0.1.4
-      args:
-        - "BOKEH_PREFIX=/dtcgweb"
-        - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
     environment:
       - "BOKEH_PREFIX=/dtcgweb"
       - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -2,7 +2,7 @@
 set -xe
 
 rm -rf repo
-git clone --branch fix-build-pathing https://github.com/gampnico/Bokeh-Docker.git repo
+git clone https://github.com/OGGM/Bokeh-Docker.git repo
 cd repo/bokeh.oggm.org
 
 docker compose down --remove-orphans

--- a/runner/run.sh
+++ b/runner/run.sh
@@ -2,7 +2,7 @@
 set -xe
 
 rm -rf repo
-git clone https://github.com/OGGM/Bokeh-Docker.git repo
+git clone --branch fix-build-pathing https://github.com/gampnico/Bokeh-Docker.git repo
 cd repo/bokeh.oggm.org
 
 docker compose down --remove-orphans


### PR DESCRIPTION
Fixes conflicting image name and removed unnecessary arguments from build context (see review in #11).
Pins DTCG-Web version to 0.1.4 which uses a release version of DTCG rather than a dev branch.

Refs: #11 