### PR TITLE
build: add new DTCG dashboard

### DIFF
--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -97,3 +97,17 @@ services:
       - "traefik.http.services.dtcgweb-app.loadbalancer.server.port=8080"
       - "traefik.http.routers.dtcgweb-app.entrypoints=web"
       - "traefik.http.routers.dtcgweb-app.rule=PathPrefix(`/dtcgweb`)"
+
+  dtcgboard-app:
+    container_name: "dtcgboard-app"
+    build:
+      context: https://github.com/DTC-Glaciers/dtcg-jupyter-dashboard.git#v0.1.0
+    restart: on-failure
+    environment:
+      - "BOKEH_PREFIX=/dtcgboard"
+      - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.dtcgboard-app.loadbalancer.server.port=8080"
+      - "traefik.http.routers.dtcgboard-app.entrypoints=web"
+      - "traefik.http.routers.dtcgboard-app.rule=PathPrefix(`/dtcgboard`)"

--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     container_name: "dtcgboard-app"
     build:
       context: https://github.com/DTC-Glaciers/dtcg-jupyter-dashboard.git#v0.1.0
-    restart: on-failure
+    # restart: on-failure
     environment:
       - "BOKEH_PREFIX=/dtcgboard"
       - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"


### PR DESCRIPTION
Adds a new Jupyter-based dashboard to ``/dtcgboard``. This runs on a Panel server.
I have kept the original dtcgweb app under the same URL while this new dashboard is being tested.

@TimoRoth I have temporarily removed the restart parameter for ``dtcgboard-app`` to avoid an infinite loop if the panel server fails to initialise properly. If the dashboard installs and runs successfully, I will add this back in.

This should probably wait until Monday before merging. 