### PR TITLE
Update dtcgweb app

### DIFF
--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -84,24 +84,26 @@ services:
       - "traefik.http.routers.hma_glacial_lakes-app.entrypoints=web"
       - "traefik.http.routers.hma_glacial_lakes-app.rule=PathPrefix(`/hma_glacial_lakes`)"
 
-#  dtcgweb-app:
-#    container_name: "dtcgweb-app"
-#    build:
-#      context: https://github.com/DTC-Glaciers/dtcg-web.git#v1.0.5
-#    restart: on-failure
-#    environment:
-#      - "BOKEH_PREFIX=/dtcgweb"
-#      - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
-#    labels:
-#      - "traefik.enable=true"
-#      - "traefik.http.services.dtcgweb-app.loadbalancer.server.port=8080"
-#      - "traefik.http.routers.dtcgweb-app.entrypoints=web"
-#      - "traefik.http.routers.dtcgweb-app.rule=PathPrefix(`/dtcgweb`)"
+  dtcgweb-app:
+   container_name: "dtcgweb-app"
+   build:
+     context: https://github.com/DTC-Glaciers/dtcg-web.git#v1.0.5
+   restart: on-failure
+   environment:
+     - "BOKEH_PREFIX=/dtcgweb"
+     - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
+   labels:
+     - "traefik.enable=true"
+     - "traefik.http.services.dtcgweb-app.loadbalancer.server.port=8080"
+     - "traefik.http.routers.dtcgweb-app.entrypoints=web"
+     - "traefik.http.routers.dtcgweb-app.rule=PathPrefix(`/dtcgweb`)"
 
   dtcgboard-app:
+   image: "ghcr.io/oggm/bokeh:20260316"
    container_name: "dtcgboard-app"
-   build:
-     context: https://github.com/DTC-Glaciers/dtcg-jupyter-dashboard.git#v0.2.0
+   command:
+     - "git+https://github.com/DTC-Glaciers/dtcg-jupyter-dashboard.git@v0.3.0"
+     - "app.ipynb"
    restart: on-failure
    environment:
      - "BOKEH_PREFIX=/dtcgboard"

--- a/bokeh.oggm.org/docker-compose.yml
+++ b/bokeh.oggm.org/docker-compose.yml
@@ -97,17 +97,17 @@ services:
 #      - "traefik.http.services.dtcgweb-app.loadbalancer.server.port=8080"
 #      - "traefik.http.routers.dtcgweb-app.entrypoints=web"
 #      - "traefik.http.routers.dtcgweb-app.rule=PathPrefix(`/dtcgweb`)"
-#
-#  dtcgboard-app:
-#    container_name: "dtcgboard-app"
-#    build:
-#      context: https://github.com/DTC-Glaciers/dtcg-jupyter-dashboard.git#v0.1.0
-#    restart: on-failure
-#    environment:
-#      - "BOKEH_PREFIX=/dtcgboard"
-#      - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
-#    labels:
-#      - "traefik.enable=true"
-#      - "traefik.http.services.dtcgboard-app.loadbalancer.server.port=8080"
-#      - "traefik.http.routers.dtcgboard-app.entrypoints=web"
-#      - "traefik.http.routers.dtcgboard-app.rule=PathPrefix(`/dtcgboard`)"
+
+  dtcgboard-app:
+   container_name: "dtcgboard-app"
+   build:
+     context: https://github.com/DTC-Glaciers/dtcg-jupyter-dashboard.git#v0.2.0
+   restart: on-failure
+   environment:
+     - "BOKEH_PREFIX=/dtcgboard"
+     - "BOKEH_ALLOW_WS_ORIGIN=${WS_ORIGIN}"
+   labels:
+     - "traefik.enable=true"
+     - "traefik.http.services.dtcgboard-app.loadbalancer.server.port=8080"
+     - "traefik.http.routers.dtcgboard-app.entrypoints=web"
+     - "traefik.http.routers.dtcgboard-app.rule=PathPrefix(`/dtcgboard`)"

--- a/bokeh.oggm.org/static/htdocs/index.html
+++ b/bokeh.oggm.org/static/htdocs/index.html
@@ -16,5 +16,5 @@ Otherwise, jump to:<br>
 <li>the <a href="explorer"> World Glaciers Explorer app</a></li>
 <li>the <a href="mb_simulator"> Mass-Balance Simulator app</a></li>
 <li>the <a href="hma_glacial_lakes"> HMA Glacial Lakes app</a></li>
-<li>the <a href="dtcgweb"> DTCG Web Dashboard</a></li>
+<li>the <a href="dtcgboard"> DTCG Web Dashboard</a></li>
 </p>

--- a/bokeh.oggm.org/static/htdocs/index.html
+++ b/bokeh.oggm.org/static/htdocs/index.html
@@ -16,5 +16,6 @@ Otherwise, jump to:<br>
 <li>the <a href="explorer"> World Glaciers Explorer app</a></li>
 <li>the <a href="mb_simulator"> Mass-Balance Simulator app</a></li>
 <li>the <a href="hma_glacial_lakes"> HMA Glacial Lakes app</a></li>
-<li>the <a href="dtcgboard"> DTCG Web Dashboard</a></li>
+<li>the <a href="dtcgweb"> DTCG Web Dashboard</a></li>
+<li>the <a href="dtcgboard"> DTCG Jupyter-Based Dashboard</a></li>
 </p>


### PR DESCRIPTION
This removes the old DTCG-web dashboard and replaces it with the Jupyter version.